### PR TITLE
Challenge 2 bronze

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -180,7 +180,7 @@ namespace GAME{
 
 
 
-        if (kbKey == SDLK_UP) {
+        //if (kbKey == SDLK_UP) {
 
             auto backInformationComponent               = ECS::ComponentManager::GetInformationComponent(backId);
             auto backKinematicTuples                    = backInformationComponent.GetKinematicTuples();
@@ -195,8 +195,9 @@ namespace GAME{
             backSpeedComponent->speed.y = maxSpeed * glm::sin(radians);
             backSpeedComponent->speed  *= -1;
 
-        }
-
+        //}
+        if(kbKey == SDLK_DOWN)
+            backSpeedComponent->speed  *= 0;
     }
 
 };

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -152,7 +152,7 @@ namespace GAME{
     }
 
     void OnTimerDone(){
-        ExitGame();
+        //ExitGame();
     }
 
     void OnEscPressed(const Uint32& kbEvent, const Sint32& kbKey){


### PR DESCRIPTION
This challenge solves the problem about that the ship doesn't turn while it moves.

The correction it happens in the file "game.cpp" in the function "OnArrowKeyPressed".

Now the ship can turn while moves and can stop when you press key down.
`

        //if (kbKey == SDLK_UP) {

            auto backInformationComponent               = ECS::ComponentManager::GetInformationComponent(backId);
            auto backKinematicTuples                    = backInformationComponent.GetKinematicTuples();
            auto [backPosId, backSpeedId, backAccelId]  = backKinematicTuples[0];
            auto backSpeedComponent                     = componentManager.GetComponentRaw<ECS::SpeedComponent_>(backSpeedId);

            auto direction                              = GAME::GetEntityDirection(componentManager, shipInformationComponent);

            auto const maxSpeed = 160.0f;
            auto radians = glm::radians(direction);
            backSpeedComponent->speed.x = maxSpeed * glm::cos(radians);
            backSpeedComponent->speed.y = maxSpeed * glm::sin(radians);
            backSpeedComponent->speed  *= -1;

        //}
        if(kbKey == SDLK_DOWN)
            backSpeedComponent->speed  *= 0;`